### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/ChronixDB/chronixDB.github.io.png?label=ready&title=Ready)](https://waffle.io/ChronixDB/chronixDB.github.io)
 # Chronix Webpage
 The Chronix website that is based on the theme freelancer (http://jekyllthemes.org/themes/freelancer/).
 It is generated using Jekyll (http://jekyllrb.com/)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/ChronixDB/chronixDB.github.io

This was requested by a real person (user ChronixDB) on waffle.io, we're not trying to spam you.
